### PR TITLE
Update Graphics Context API Calls

### DIFF
--- a/YYText/Utility/YYTextAsyncLayer.m
+++ b/YYText/Utility/YYTextAsyncLayer.m
@@ -125,7 +125,7 @@ static dispatch_queue_t YYTextAsyncLayerGetReleaseQueue() {
         if (task.didDisplay) task.didDisplay(self, YES);
         return;
     }
-    
+
     if (async) {
         if (task.willDisplay) task.willDisplay(self);
         _YYTextSentinel *sentinel = _sentinel;
@@ -149,7 +149,7 @@ static dispatch_queue_t YYTextAsyncLayerGetReleaseQueue() {
             CGColorRelease(backgroundColor);
             return;
         }
-        
+
         dispatch_async(YYTextAsyncLayerGetDisplayQueue(), ^{
             if (isCancelled()) {
                 CGColorRelease(backgroundColor);
@@ -200,28 +200,28 @@ static dispatch_queue_t YYTextAsyncLayerGetReleaseQueue() {
     } else {
         [_sentinel increase];
         if (task.willDisplay) task.willDisplay(self);
-        UIGraphicsBeginImageContextWithOptions(self.bounds.size, self.opaque, self.contentsScale);
-        CGContextRef context = UIGraphicsGetCurrentContext();
-        if (self.opaque && context) {
-            CGSize size = self.bounds.size;
-            size.width *= self.contentsScale;
-            size.height *= self.contentsScale;
-            CGContextSaveGState(context); {
-                if (!self.backgroundColor || CGColorGetAlpha(self.backgroundColor) < 1) {
-                    CGContextSetFillColorWithColor(context, [UIColor whiteColor].CGColor);
-                    CGContextAddRect(context, CGRectMake(0, 0, size.width, size.height));
-                    CGContextFillPath(context);
-                }
-                if (self.backgroundColor) {
-                    CGContextSetFillColorWithColor(context, self.backgroundColor);
-                    CGContextAddRect(context, CGRectMake(0, 0, size.width, size.height));
-                    CGContextFillPath(context);
-                }
-            } CGContextRestoreGState(context);
-        }
-        task.display(context, self.bounds.size, ^{return NO;});
-        UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
-        UIGraphicsEndImageContext();
+
+        UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:self.bounds.size];
+        UIImage *image = [renderer imageWithActions:^(UIGraphicsImageRendererContext * _Nonnull context) {
+            if (self.opaque && context) {
+                CGSize size = self.bounds.size;
+                size.width *= self.contentsScale;
+                size.height *= self.contentsScale;
+                CGContextSaveGState(context.CGContext); {
+                    if (!self.backgroundColor || CGColorGetAlpha(self.backgroundColor) < 1) {
+                        CGContextSetFillColorWithColor(context.CGContext, [UIColor whiteColor].CGColor);
+                        CGContextAddRect(context.CGContext, CGRectMake(0, 0, size.width, size.height));
+                        CGContextFillPath(context.CGContext);
+                    }
+                    if (self.backgroundColor) {
+                        CGContextSetFillColorWithColor(context.CGContext, self.backgroundColor);
+                        CGContextAddRect(context.CGContext, CGRectMake(0, 0, size.width, size.height));
+                        CGContextFillPath(context.CGContext);
+                    }
+                } CGContextRestoreGState(context.CGContext);
+            }
+            task.display(context.CGContext, self.bounds.size, ^{return NO;});
+        }];
         self.contents = (__bridge id)(image.CGImage);
         if (task.didDisplay) task.didDisplay(self, YES);
     }


### PR DESCRIPTION
UIGraphicsBeginImageContextWithOptions is now deprecated. Using the new API to allow usage on iOS 17 Simulators