### PR TITLE
fix get highlight nullability

### DIFF
--- a/YYText/YYLabel.h
+++ b/YYText/YYLabel.h
@@ -46,7 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
   We expose this method to find our YYTextHighlight, so we can track when a user is touching
  a link.
  */
-- (YYTextHighlight *)_getHighlightAtPoint:(CGPoint)point range:(NSRangePointer)range;
+- (nullable YYTextHighlight *)_getHighlightAtPoint:(CGPoint)point range:(NSRangePointer)range;
 
 #pragma mark - Accessing the Text Attributes
 ///=============================================================================


### PR DESCRIPTION
the method `_getHighlightAtPoint` can possibly return `nil`. but because of `NS_ASSUME_NONNULL_BEGIN` the method signature reads as if it cannot. this is a problem from a Swift context because the compiler will not allow you to treat the resulting value as potentially `nil`.