### PR TITLE
fix wrong cached height bug

### DIFF
--- a/YYText/Component/YYTextLayout.h
+++ b/YYText/Component/YYTextLayout.h
@@ -251,6 +251,8 @@ extern const CGSize YYTextContainerMaxSize;
 @property (nonatomic, readonly) CGSize textBoundingSize;
 ///< Has highlight attribute
 @property (nonatomic, readonly) BOOL containsHighlight;
+/// True if the current text does not fit in the constrained frame.
+@property (nonatomic, readonly) BOOL needTruncation;
 ///< Has block border attribute
 @property (nonatomic, readonly) BOOL needDrawBlockBorder;
 ///< Has background border attribute

--- a/YYText/Component/YYTextLayout.m
+++ b/YYText/Component/YYTextLayout.m
@@ -328,6 +328,7 @@ dispatch_semaphore_signal(_lock);
 @property (nonatomic, readwrite) CGSize textBoundingSize;
 
 @property (nonatomic, readwrite) BOOL containsHighlight;
+@property (nonatomic, readwrite) BOOL needTruncation;
 @property (nonatomic, readwrite) BOOL needDrawBlockBorder;
 @property (nonatomic, readwrite) BOOL needDrawBackgroundBorder;
 @property (nonatomic, readwrite) BOOL needDrawShadow;
@@ -674,6 +675,7 @@ dispatch_semaphore_signal(_lock);
     
     visibleRange = YYTextNSRangeFromCFRange(CTFrameGetVisibleStringRange(ctFrame));
     if (needTruncation) {
+        layout.needTruncation = YES;
         YYTextLine *lastLine = lines.lastObject;
         NSRange lastRange = lastLine.range;
         visibleRange.length = lastRange.location + lastRange.length - visibleRange.location;

--- a/YYText/YYLabel.m
+++ b/YYText/YYLabel.m
@@ -505,7 +505,7 @@ static dispatch_queue_t YYLabelGetReleaseQueue() {
         YYTextLayout *layout = self._innerLayout;
         BOOL contains = NO;
         if (layout.container.maximumNumberOfRows == 0) {
-            if (layout.truncatedLine == nil) {
+            if (!layout.needTruncation) {
                 contains = YES;
             }
         } else {


### PR DESCRIPTION
this tricky bug has been a problem for a while - causing sometimes incorrect text height renders. this most frequently manifested in embed views. i had a very reproducible case when going to this embed: https://canary.discord.com/channels/1199152226233483358/1408562610210869333/1440023875394994308

i think which specific embed causes the issue varies based on device size & dynamic font settings - for this, I was running on an iPhone 16 Pro simulator with normal text size:
<img width="379" height="104" alt="image" src="https://github.com/user-attachments/assets/64fb196d-9640-4527-91b9-94f50d756714" />

after tapping the above message, I get it clipped the majority of the time:

<img width="400" height="310" alt="image" src="https://github.com/user-attachments/assets/e9d9b6de-d9be-4944-8d77-637c6705c507" />

basically, what's happening is that `YYText` uses the presence of a `truncationLine` as a proxy to determine whether we need to re-do layout or not. the idea being that if there is a `truncationLine`, it means we don't have enough room for the text, which means we need to redo layout.

however, it's very possible for the text to not fit into the bounding box and for the `truncationLine` to be `nil` anyway - for example, if the `truncationType` is `None` (which it is in many cases). which means that `truncationLine` is not a good proxy for whether the text gets clipped or not. in the `YYTextLayout` logic, I found a `needTruncation` boolean that I decided to just expose. it seems a more suitable proxy.

after changing the logic from checking `layout.truncatedLine == nil` to instead checking `!layout.needTruncation`, the bug no longer manifests for me locally:

<img width="401" height="420" alt="image" src="https://github.com/user-attachments/assets/dcffa6d8-30d9-4297-b26d-1c540e9ff432" />
